### PR TITLE
Add hopper make target

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -17,3 +17,8 @@ clippy:
 
 test:
     cargo make test
+
+alias disasm := hopper
+
+hopper:
+    cargo make hopper

--- a/README.md
+++ b/README.md
@@ -35,19 +35,19 @@ Use at least rustc nightly 2020-07-15 with cargo nightly of the same or later da
 Install tools: `cargo install just cargo-make`.
 Install qemu (at least version 4.1.1): `brew install qemu`.
 
-To build kernel and run it in QEMU emulator:
+### To build kernel and run it in QEMU emulator
 
 ```
 just qemu
 ```
 
-To build kernel for Raspberry Pi and copy it to SDCard mounted at `/Volumes/BOOT/`:
+### To build kernel for Raspberry Pi and copy it to SDCard mounted at `/Volumes/BOOT/`
 
 ```
 just device
 ```
 
-To run tests (tests require QEMU):
+### To run tests (tests require QEMU)
 
 ```
 just test
@@ -58,6 +58,14 @@ On the device boot SD card you'll need a configuration file instructing RasPi to
 ```
 # config.txt on RPi3
 arm_64bit=1
+```
+
+### To see kernel disassembly
+
+You need to have [Hopper](https://hopperapp.com) and hopperv4 cli helper installed.
+
+```
+just disasm
 ```
 
 ## Development flow

--- a/nucleus/Makefile.toml
+++ b/nucleus/Makefile.toml
@@ -70,3 +70,11 @@ args = ["unmount", "/Volumes/BOOT/"]
 [tasks.clippy]
 command = "cargo"
 args = ["clippy", "${BUILD_STD}", "--target=${TARGET_JSON}", "--", "-D", "warnings"]
+
+[tasks.hopper]
+dependencies = ["build", "kernel-binary"]
+# The cmd line below causes a bug in hopper, see https://www.dropbox.com/s/zyw5mfx0bepcjb1/hopperv4-RAW-bug.mov?dl=0
+#"hopperv4 --loader RAW --base-address 0x80000 --entrypoint 0x80000 --file-offset 0 --plugin arm --cpu aarch64 --variant generic --contains-code true --executable ${KERNEL_BIN}"
+script = [
+    "hopperv4 --loader ELF --executable ${KERNEL_ELF}"
+]


### PR DESCRIPTION
hopper is useful for inspecting kernel disassembly.