### PR TITLE
Fix/code cleanup

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,5 @@
+[unstable]
+build-std = ["core", "compiler_builtins", "alloc"]
 [build]
 # https://internals.rust-lang.org/t/evaluating-pipelined-rustc-compilation/10199/12
 pipelining = true

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,7 @@
 [unstable]
 build-std = ["core", "compiler_builtins", "alloc"]
+build-std-features = ["compiler-builtins-mem"]
+
 [build]
 # https://internals.rust-lang.org/t/evaluating-pipelined-rustc-compilation/10199/12
 pipelining = true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
         ]
 
     runs-on: ${{ matrix.platform }}
-    timeout-minutes: 20
+    timeout-minutes: 30
 
     steps:
     - name: "Checkout Repository"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,9 +20,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cortex-a"
-version = "4.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda21b8ec67b82099401559fe28cea4508eb1e33217b4dacf60ba22e39b486b1"
+checksum = "a389514c1229e12a03c0e8de8b357671b71e1d1bdab3a4f5b591abc94169cba8"
 dependencies = [
  "register",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,12 +73,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rlibc"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc874b127765f014d792f16763a81245ab80500e2ad921ed4ee9e82481ee08fe"
-
-[[package]]
 name = "snafu"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,7 +139,6 @@ dependencies = [
  "qemu-exit",
  "r0",
  "register",
- "rlibc",
  "snafu",
  "usize_conversions",
  "ux",

--- a/Justfile
+++ b/Justfile
@@ -42,3 +42,7 @@ gdb:
 nm:
     # Build and print all symbols in the kernel
     cargo make nm
+
+expand:
+    # Run `cargo expand` on modules
+    cargo make expand -- nucleus

--- a/Justfile
+++ b/Justfile
@@ -1,7 +1,9 @@
 qemu:
+    # Build and run kernel in QEMU
     cargo make qemu
 
 device:
+    # Build and write kernel to an SD Card
     cargo make sdcard
 
 build:
@@ -9,27 +11,34 @@ build:
     cargo make build
 
 clean:
+    # Clean project
     cargo make clean
     rm -f kernel8 kernel8.img
 
 clippy:
+    # Run clippy checks
     cargo make clippy
 
 test:
+    # Run tests in QEMU
     cargo make test
 
 alias disasm := hopper
 
 hopper:
+    # Build and disassemble kernel
     cargo make hopper
 
 alias ocd := openocd
 
 openocd:
+    # Start openocd (by default connected via JTAG to a target device)
     cargo make openocd
 
 gdb:
+    # Build and run kernel in GDB using openocd or QEMU as target (gdb port 5555)
     cargo make gdb
 
 nm:
+    # Build and print all symbols in the kernel
     cargo make nm

--- a/Justfile
+++ b/Justfile
@@ -30,3 +30,6 @@ openocd:
 
 gdb:
     cargo make gdb
+
+nm:
+    cargo make nm

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -61,6 +61,8 @@ QEMU_TESTS_OPTS = "-nographic"
 # - port 5555 used to match JLink configuration, so we can reuse the same GDB command for both QEMU and JTAG.
 QEMU_GDB_OPTS = "-gdb tcp::5555 -S"
 
+GDB_CONNECT_FILE = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/target/${TARGET}/gdb-connect"
+
 KERNEL_ELF = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/kernel8"
 KERNEL_BIN = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/kernel8.img"
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -36,8 +36,6 @@ CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
 
 TARGET_JSON = "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/targets/${TARGET}.json"
 
-BUILD_STD = "-Zbuild-std=core,compiler_builtins,alloc"
-
 DEVICE_FEATURES = "noserial"
 QEMU_FEATURES = "qemu"
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Vesper has been influenced by the kernels in L4 family, notably seL4. Fawn and N
 
 ## Build instructions
 
-Use at least rustc nightly 2020-07-15 with cargo nightly of the same or later date. It adds support for `cargo build --build-std` feature.
+Use at least rustc nightly 2020-09-30 with cargo nightly of the same or later date. It adds support for `cargo build --build-std` feature (since 2020-07-15) and support for compiler_builtins memory operations ([since 2020-09-30](https://github.com/rust-lang/rust/pull/77284)).
 
 * Install tools: `cargo install just cargo-make`.
 * Install qemu (at least version 4.1.1): `brew install qemu`.

--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ just gdb
 
 If you launch OpenOCD or QEMU before, then gdb shall connect to it and allow you to load the kernel binary directly into memory. Type `load` in gdb to do that.
 
+### To see kernel symbols and their values
+
+```
+just nm
+```
+
 ### To see kernel disassembly
 
 You need to have [Hopper](https://hopperapp.com) and hopperv4 cli helper installed.

--- a/linker/aarch64.ld
+++ b/linker/aarch64.ld
@@ -14,7 +14,7 @@ ENTRY(_boot_cores);
 SECTIONS
 {
     . = 0x80000; /* AArch64 boot address is 0x80000, 4K-aligned */
-    __STACK_START = .; /* Stack grows from here on down. */
+    __STACK_START = 0x80000; /* Stack grows from here towards 0x0. */
     __BOOT_START = .;
     .text :
     {

--- a/nucleus/Cargo.toml
+++ b/nucleus/Cargo.toml
@@ -25,7 +25,6 @@ qemu = ["qemu-exit"]
 
 [dependencies]
 r0 = "1.0"
-rlibc = "1.0"
 qemu-exit = { version = "1.0", optional = true }
 cortex-a = "4.0"
 ux = { version = "0.1.3", default-features = false }

--- a/nucleus/Cargo.toml
+++ b/nucleus/Cargo.toml
@@ -26,7 +26,7 @@ qemu = ["qemu-exit"]
 [dependencies]
 r0 = "1.0"
 qemu-exit = { version = "1.0", optional = true }
-cortex-a = "4.0"
+cortex-a = "4.1.0"
 ux = { version = "0.1.3", default-features = false }
 usize_conversions = "0.2.0"
 bit_field = "0.10.0"

--- a/nucleus/Makefile.toml
+++ b/nucleus/Makefile.toml
@@ -7,6 +7,10 @@
 env = { "TARGET_FEATURES" = "" }
 args = ["build", "--target=${TARGET_JSON}", "--release", "--features=${TARGET_FEATURES}"]
 
+[tasks.expand]
+env = { "TARGET_FEATURES" = "" }
+args = ["expand", "--target=${TARGET_JSON}", "--release", "--features=${TARGET_FEATURES}"]
+
 [tasks.test]
 env = { "TARGET_FEATURES" = "${QEMU_FEATURES}" }
 args = ["test", "--target=${TARGET_JSON}", "--features=${TARGET_FEATURES}"]

--- a/nucleus/Makefile.toml
+++ b/nucleus/Makefile.toml
@@ -5,11 +5,11 @@
 #
 [tasks.build]
 env = { "TARGET_FEATURES" = "" }
-args = ["build", "${BUILD_STD}", "--target=${TARGET_JSON}", "--release", "--features=${TARGET_FEATURES}"]
+args = ["build", "--target=${TARGET_JSON}", "--release", "--features=${TARGET_FEATURES}"]
 
 [tasks.test]
 env = { "TARGET_FEATURES" = "${QEMU_FEATURES}" }
-args = ["test", "${BUILD_STD}", "--target=${TARGET_JSON}", "--features=${TARGET_FEATURES}"]
+args = ["test", "--target=${TARGET_JSON}", "--features=${TARGET_FEATURES}"]
 
 # These tasks are written in cargo-make's own script to make it portable across platforms (no `basename` on Windows)
 [tasks.kernel-binary]
@@ -44,7 +44,7 @@ script = [
 [tasks.build-qemu]
 env = { "TARGET_FEATURES" = "${QEMU_FEATURES}" }
 command = "cargo"
-args = ["build", "${BUILD_STD}", "--target=${TARGET_JSON}", "--release", "--features=${TARGET_FEATURES}"]
+args = ["build", "--target=${TARGET_JSON}", "--release", "--features=${TARGET_FEATURES}"]
 
 [tasks.qemu]
 dependencies = ["build-qemu", "kernel-binary"]
@@ -104,7 +104,7 @@ script = [
 [tasks.clippy]
 env = { "TARGET_FEATURES" = { value = "--features=${CLIPPY_FEATURES}", condition = { env_set = ["CLIPPY_FEATURES"] } } }
 command = "cargo"
-args = ["clippy", "${BUILD_STD}", "--target=${TARGET_JSON}", "@@remove-empty(TARGET_FEATURES)", "--", "-D", "warnings"]
+args = ["clippy", "--target=${TARGET_JSON}", "@@remove-empty(TARGET_FEATURES)", "--", "-D", "warnings"]
 
 [tasks.hopper]
 dependencies = ["build", "kernel-binary"]

--- a/nucleus/Makefile.toml
+++ b/nucleus/Makefile.toml
@@ -78,6 +78,13 @@ script = [
     "rust-gdb -x ${GDB_CONNECT_FILE} ${KERNEL_ELF}"
 ]
 
+[tasks.nm]
+dependencies = ["build", "kernel-binary"]
+script = [
+    "${NM} -- ${KERNEL_ELF} | sort"
+]
+#install_crate = "cargo-binutils"
+
 [tasks.sdcard]
 dependencies = ["build", "kernel-binary"]
 script_runner = "@duckscript"

--- a/nucleus/Makefile.toml
+++ b/nucleus/Makefile.toml
@@ -63,16 +63,19 @@ script = [
     "${OPENOCD} -f interface/jlink.cfg -f ../doc/rpi2rpi_jtag/rpi3_target.cfg"
 ]
 
-[tasks.gdb]
-dependencies = ["build", "kernel-binary"]
-env = { "RUST_GDB" = "${GDB}" }
+[tasks.gdb-config]
 script_runner = "@duckscript"
 script = [
 '''
-    connectFile = set ${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/target/${TARGET}/gdb-connect
-    writefile ${connectFile} "target remote :5555\n"
-    exec --fail-on-error rust-gdb -x ${connectFile} ${KERNEL_ELF}
+    writefile ${GDB_CONNECT_FILE} "target remote :5555\n"
 '''
+]
+
+[tasks.gdb]
+dependencies = ["build", "kernel-binary", "gdb-config"]
+env = { "RUST_GDB" = "${GDB}" }
+script = [
+    "rust-gdb -x ${GDB_CONNECT_FILE} ${KERNEL_ELF}"
 ]
 
 [tasks.sdcard]

--- a/nucleus/src/arch/aarch64/boot.rs
+++ b/nucleus/src/arch/aarch64/boot.rs
@@ -77,6 +77,7 @@ fn shared_setup_and_enter_pre() {
         SCTLR_EL1::I::NonCacheable
             + SCTLR_EL1::C::NonCacheable
             + SCTLR_EL1::M::Disable
+            + SCTLR_EL1::A::Disable,
     );
 
     // Set Hypervisor Configuration Register (EL2)
@@ -142,18 +143,18 @@ fn setup_and_enter_el1_from_el3() -> ! {
     // Set Secure Configuration Register (EL3)
     SCR_EL3.write(SCR_EL3::RW::NextELIsAarch64 + SCR_EL3::NS::NonSecure);
 
-        // Set Saved Program Status Register (EL3)
-        // Set up a simulated exception return.
-        //
-        // First, fake a saved program status, where all interrupts were
-        // masked and SP_EL1 was used as a stack pointer.
-        SPSR_EL3.write(
-            SPSR_EL3::D::Masked
-                + SPSR_EL3::A::Masked
-                + SPSR_EL3::I::Masked
-                + SPSR_EL3::F::Masked
-                + SPSR_EL3::M::EL1h, // Use SP_EL1
-        );
+    // Set Saved Program Status Register (EL3)
+    // Set up a simulated exception return.
+    //
+    // First, fake a saved program status, where all interrupts were
+    // masked and SP_EL1 was used as a stack pointer.
+    SPSR_EL3.write(
+        SPSR_EL3::D::Masked
+            + SPSR_EL3::A::Masked
+            + SPSR_EL3::I::Masked
+            + SPSR_EL3::F::Masked
+            + SPSR_EL3::M::EL1h, // Use SP_EL1
+    );
 
     // Make the Exception Link Register (EL3) point to reset().
     ELR_EL3.set(reset as *const () as u64);

--- a/nucleus/src/arch/aarch64/boot.rs
+++ b/nucleus/src/arch/aarch64/boot.rs
@@ -183,6 +183,8 @@ pub unsafe extern "C" fn _boot_cores() -> ! {
     const EL2: u64 = CurrentEL::EL::EL2.value;
     const EL1: u64 = CurrentEL::EL::EL1.value;
 
+    SP.set(STACK_START);
+
     if CORE_0 == MPIDR_EL1.get() & CORE_MASK {
         match CurrentEL.get() {
             #[cfg(qemu)]

--- a/nucleus/src/arch/aarch64/memory/mmu.rs
+++ b/nucleus/src/arch/aarch64/memory/mmu.rs
@@ -175,7 +175,7 @@ pub fn print_features() {
     }
 
     let t0sz = tcr.read(TCR_EL1::T0SZ);
-    println!("[i] MMU: T0sz = 64-{}={} bits", t0sz, 64 - t0sz);
+    println!("[i] MMU: T0sz = 64-{} = {} bits", t0sz, 64 - t0sz);
 
     match tcr.read_as_enum(TCR_EL1::TG1) {
         Some(TCR_EL1::TG1::Value::KiB_4) => println!("[i] MMU: TTBR1 4 KiB granule active!"),
@@ -185,7 +185,7 @@ pub fn print_features() {
     }
 
     let t1sz = tcr.read(TCR_EL1::T1SZ);
-    println!("[i] MMU: T1sz = 64-{}={} bits", t1sz, 64 - t1sz);
+    println!("[i] MMU: T1sz = 64-{} = {} bits", t1sz, 64 - t1sz);
 }
 
 register_bitfields! {

--- a/nucleus/src/arch/aarch64/memory/mmu.rs
+++ b/nucleus/src/arch/aarch64/memory/mmu.rs
@@ -188,7 +188,8 @@ pub fn print_features() {
     println!("[i] MMU: T1sz = 64-{}={} bits", t1sz, 64 - t1sz);
 }
 
-register_bitfields! {u64,
+register_bitfields! {
+    u64,
     // AArch64 Reference Manual page 2150, D5-2445
     STAGE1_DESCRIPTOR [
         // In table descriptors

--- a/nucleus/src/arch/aarch64/traps.rs
+++ b/nucleus/src/arch/aarch64/traps.rs
@@ -55,6 +55,7 @@ use {
         barrier,
         regs::{RegisterReadOnly, RegisterReadWrite, ESR_EL1, FAR_EL1, VBAR_EL1},
     },
+    register::{register_bitfields, LocalRegisterCopy},
     snafu::Snafu,
 };
 
@@ -151,6 +152,152 @@ unsafe extern "C" fn current_elx_serror(e: &mut ExceptionContext) {
     endless_sleep()
 }
 
+fn cause_to_string(cause: u64) -> &'static str {
+    if cause == ESR_EL1::EC::DataAbortCurrentEL.read(ESR_EL1::EC) {
+        "Data Alignment Check"
+    } else {
+        "Unknown"
+    }
+}
+
+register_bitfields! {
+    u64,
+    /// ISS structure for Data Abort exceptions
+    ISS_DA [
+        /// Instruction Syndrome Valid. Indicates whether the syndrome information in ISS[23:14] is valid.
+        /// (This includes SAS, SSE, SRT, SF, and AR)
+        ISV   OFFSET(24) NUMBITS(1) [],
+        SAS   OFFSET(22) NUMBITS(2) [
+            Byte = 0b00,
+            Halfword = 0b01,
+            Word = 0b10,
+            DoubleWord = 0b11
+        ],
+        SSE   OFFSET(21) NUMBITS(1) [],
+        SRT   OFFSET(16) NUMBITS(5) [],
+        SF    OFFSET(15) NUMBITS(1) [],
+        AR    OFFSET(14) NUMBITS(1) [],
+        VNCR  OFFSET(13) NUMBITS(1) [],
+        SET   OFFSET(11) NUMBITS(2) [
+            UER = 0b00, // Recoverable state
+            UC = 0b10, // Uncontainable
+            UEO = 0b11 // Restartable state
+        ],
+        FNV   OFFSET(10) NUMBITS(1) [],
+        EA    OFFSET(9)  NUMBITS(1) [],
+        CM    OFFSET(8)  NUMBITS(1) [],
+        S1PTW OFFSET(7)  NUMBITS(1) [],
+        WNR   OFFSET(6)  NUMBITS(1) [],
+        DFSC  OFFSET(0)  NUMBITS(6) [
+            /// Address size fault, level 0 of translation or translation table base register.
+            AddressSizeTL0 = 0b000000,
+            /// Address size fault, level 1.
+            AddressSizeTL1 = 0b000001,
+            ///Address size fault, level 2.
+            AddressSizeTL2 = 0b000010,
+            /// Address size fault, level 3.
+            AddressSizeTL3 = 0b000011,
+            /// Translation fault, level 0.
+            TranslationFaultTL0 = 0b000100,
+            /// Translation fault, level 1.
+            TranslationFaultTL1 = 0b000101,
+            /// Translation fault, level 2.
+            TranslationFaultTL2 = 0b000110,
+            /// Translation fault, level 3.
+            TranslationFaultTL3 = 0b000111,
+            /// Access flag fault, level 1.
+            AccessFaultTL1 = 0b001001,
+            /// Access flag fault, level 2.
+            AccessFaultTL2 = 0b001010,
+            /// Access flag fault, level 3.
+            AccessFaultTL3 = 0b001011,
+            /// Permission fault, level 1.
+            PermissionFaultTL1 = 0b001101,
+            /// Permission fault, level 2.
+            PermissionFaultTL2 = 0b001110,
+            /// Permission fault, level 3.
+            PermissionFaultTL3 = 0b001111,
+            /// Synchronous External abort, not on translation table walk or hardware update of translation table.
+            SyncExternalAbort = 0b010000,
+            /// Synchronous Tag Check Fault.
+            /// (When FEAT_MTE is implemented)
+            SyncTagCheckFault = 0b010001,
+            /// Synchronous External abort on translation table walk or hardware update of translation table, level 0.
+            SyncAbortOnTranslationTL0 = 0b010100,
+            /// Synchronous External abort on translation table walk or hardware update of translation table, level 1.
+            SyncAbortOnTranslationTL1 = 0b010101,
+            /// Synchronous External abort on translation table walk or hardware update of translation table, level 2.
+            SyncAbortOnTranslationTL2 = 0b010110,
+            /// Synchronous External abort on translation table walk or hardware update of translation table, level 3.
+            SyncAbortOnTranslationTL3 = 0b010111,
+            /// Synchronous parity or ECC error on memory access, not on translation table walk.
+            /// (When FEAT_RAS is not implemented)
+            SyncParityError = 0b011000,
+            /// Synchronous parity or ECC error on memory access on translation table walk or hardware update of translation table, level 0.
+            /// (When FEAT_RAS is not implemented)
+            SyncParityErrorOnTranslationTL0 = 0b011100,
+            /// Synchronous parity or ECC error on memory access on translation table walk or hardware update of translation table, level 1.
+            /// (When FEAT_RAS is not implemented)
+            SyncParityErrorOnTranslationTL1 = 0b011101,
+            /// Synchronous parity or ECC error on memory access on translation table walk or hardware update of translation table, level 2.
+            /// (When FEAT_RAS is not implemented)
+            SyncParityErrorOnTranslationTL2 = 0b011110,
+            /// Synchronous parity or ECC error on memory access on translation table walk or hardware update of translation table, level 3.
+            /// (When FEAT_RAS is not implemented)
+            SyncParityErrorOnTranslationTL3 = 0b011111,
+            /// Alignment fault.
+            AlignmentFault = 0b100001,
+            /// TLB conflict abort.
+            TlbConflictAbort = 0b110000,
+            /// Unsupported atomic hardware update fault.
+            /// (When FEAT_HAFDBS is implemented)
+            UnsupportedAtomicUpdate = 0b110001,
+            /// IMPLEMENTATION DEFINED fault (Lockdown).
+            Lockdown = 0b110100,
+            /// IMPLEMENTATION DEFINED fault (Unsupported Exclusive or Atomic access).
+            UnsupportedAccess = 0b110101
+        ]
+    ]
+}
+
+type IssForDataAbort = LocalRegisterCopy<u64, ISS_DA::Register>;
+
+fn iss_dfsc_to_string(iss: IssForDataAbort) -> &'static str {
+    match iss.read_as_enum(ISS_DA::DFSC) {
+        Some(ISS_DA::DFSC::Value::AddressSizeTL0) => "Address size fault, level 0 of translation or translation table base register",
+        Some(ISS_DA::DFSC::Value::AddressSizeTL1) => "Address size fault, level 1",
+        Some(ISS_DA::DFSC::Value::AddressSizeTL2) => "Address size fault, level 2",
+        Some(ISS_DA::DFSC::Value::AddressSizeTL3) => "Address size fault, level 3",
+        Some(ISS_DA::DFSC::Value::TranslationFaultTL0) => "Translation fault, level 0",
+        Some(ISS_DA::DFSC::Value::TranslationFaultTL1) => "Translation fault, level 1",
+        Some(ISS_DA::DFSC::Value::TranslationFaultTL2) => "Translation fault, level 2",
+        Some(ISS_DA::DFSC::Value::TranslationFaultTL3) => "Translation fault, level 3",
+        Some(ISS_DA::DFSC::Value::AccessFaultTL1) => "Access flag fault, level 1",
+        Some(ISS_DA::DFSC::Value::AccessFaultTL2) => "Access flag fault, level 2",
+        Some(ISS_DA::DFSC::Value::AccessFaultTL3) => "Access flag fault, level 3",
+        Some(ISS_DA::DFSC::Value::PermissionFaultTL1) => "Permission fault, level 1",
+        Some(ISS_DA::DFSC::Value::PermissionFaultTL2) => "Permission fault, level 2",
+        Some(ISS_DA::DFSC::Value::PermissionFaultTL3) => "Permission fault, level 3",
+        Some(ISS_DA::DFSC::Value::SyncExternalAbort) => "Synchronous External abort, not on translation table walk or hardware update of translation table",
+        Some(ISS_DA::DFSC::Value::SyncTagCheckFault) => "Synchronous Tag Check Fault",
+        Some(ISS_DA::DFSC::Value::SyncAbortOnTranslationTL0) => "Synchronous External abort on translation table walk or hardware update of translation table, level 0",
+        Some(ISS_DA::DFSC::Value::SyncAbortOnTranslationTL1) => "Synchronous External abort on translation table walk or hardware update of translation table, level 1",
+        Some(ISS_DA::DFSC::Value::SyncAbortOnTranslationTL2) => "Synchronous External abort on translation table walk or hardware update of translation table, level 2",
+        Some(ISS_DA::DFSC::Value::SyncAbortOnTranslationTL3) => "Synchronous External abort on translation table walk or hardware update of translation table, level 3",
+        Some(ISS_DA::DFSC::Value::SyncParityError) => "Synchronous parity or ECC error on memory access, not on translation table walk",
+        Some(ISS_DA::DFSC::Value::SyncParityErrorOnTranslationTL0) => "Synchronous parity or ECC error on memory access on translation table walk or hardware update of translation table, level 0",
+        Some(ISS_DA::DFSC::Value::SyncParityErrorOnTranslationTL1) => "Synchronous parity or ECC error on memory access on translation table walk or hardware update of translation table, level 1",
+        Some(ISS_DA::DFSC::Value::SyncParityErrorOnTranslationTL2) => "Synchronous parity or ECC error on memory access on translation table walk or hardware update of translation table, level 2",
+        Some(ISS_DA::DFSC::Value::SyncParityErrorOnTranslationTL3) => "Synchronous parity or ECC error on memory access on translation table walk or hardware update of translation table, level 3",
+        Some(ISS_DA::DFSC::Value::AlignmentFault) => "Alignment fault",
+        Some(ISS_DA::DFSC::Value::TlbConflictAbort) => "TLB conflict abort",
+        Some(ISS_DA::DFSC::Value::UnsupportedAtomicUpdate) => "Unsupported atomic hardware update fault",
+        Some(ISS_DA::DFSC::Value::Lockdown) => "Lockdown (IMPLEMENTATION DEFINED fault)",
+        Some(ISS_DA::DFSC::Value::UnsupportedAccess) => "Unsupported Exclusive or Atomic access (IMPLEMENTATION DEFINED fault)",
+        _ => "Unknown",
+    }
+}
+
 // unsafe extern "C" fn lower_aarch64_synchronous(e: &mut ExceptionContext);
 // unsafe extern "C" fn lower_aarch64_irq(e: &mut ExceptionContext);
 // unsafe extern "C" fn lower_aarch64_serror(e: &mut ExceptionContext);
@@ -163,12 +310,62 @@ unsafe extern "C" fn current_elx_serror(e: &mut ExceptionContext) {
 /// Not for production use!
 fn synchronous_common(e: &mut ExceptionContext) {
     println!("      ESR_EL1: {:#010x} (syndrome)", ESR_EL1.get());
-    println!("           EC: {:#06b} (cause)", ESR_EL1.read(ESR_EL1::EC));
-    println!("      FAR_EL1: {:#016x} (location)", FAR_EL1.get());
-    println!("      ELR_EL1: {:#010x}", e.elr_el1);
+    let cause = ESR_EL1.read(ESR_EL1::EC);
+    println!(
+        "           EC: {:#06b} (cause) -- {}",
+        cause,
+        cause_to_string(cause)
+    );
+
+    // Print more details about Data Alignment Check
+    if cause == ESR_EL1::EC::DataAbortCurrentEL.read(ESR_EL1::EC) {
+        let iss = ESR_EL1.read(ESR_EL1::ISS);
+        let iss = IssForDataAbort::new(iss);
+        if iss.is_set(ISS_DA::ISV) {
+            println!(
+                "               Access size: {} bytes ({}signed) to {}{}",
+                2u64.pow(iss.read(ISS_DA::SAS) as u32),
+                if iss.is_set(ISS_DA::SSE) { "" } else { "un" },
+                if iss.is_set(ISS_DA::SF) { "x" } else { "r" },
+                iss.read(ISS_DA::SRT)
+            );
+            println!(
+                "               Acq/Rel semantics: {}present",
+                if iss.is_set(ISS_DA::AR) { "" } else { "not " }
+            );
+        }
+        // data abort specific encoding
+        println!(
+            "               {} address {:#016x} ({}valid)",
+            if iss.is_set(ISS_DA::WNR) {
+                "Writing to"
+            } else {
+                "Reading from"
+            },
+            FAR_EL1.get(),
+            if iss.is_set(ISS_DA::FNV) { "not " } else { "" }
+        );
+        println!("               Specific fault: {}", iss_dfsc_to_string(iss));
+    } else {
+        println!("      FAR_EL1: {:#016x} (location)", FAR_EL1.get());
+        println!("        Stack: {:#016x}", e.spsr_el1);
+        println!("      ELR_EL1: {:#010x}", e.elr_el1);
+    }
+
+    println!("      x00: 0000000000000000    x01: {:016x}", e.gpr.x[0]);
+
+    for index in 0..15 {
+        println!(
+            "      x{:02}: {:016x}    x{:02}: {:016x}",
+            index * 2 + 2,
+            e.gpr.x[index * 2 + 1],
+            index * 2 + 3,
+            e.gpr.x[index * 2 + 2]
+        );
+    }
 
     println!(
-        "      Incrementing ELR_EL1 by 4 now to continue with the first \
+        "      Incrementing ELR_EL1 by 4 to continue with the first \
          instruction after the exception!"
     );
 

--- a/nucleus/src/macros.rs
+++ b/nucleus/src/macros.rs
@@ -36,6 +36,6 @@ pub fn _print(args: core::fmt::Arguments) {
 pub fn _print(args: core::fmt::Arguments) {
     use crate::{qemu, write_to};
 
-    let mut buf = [0u8; 512];
+    let mut buf = [0u8; 2048]; // Increase this buffer size to allow dumping larger panic texts.
     qemu::semihosting::sys_write0_call(write_to::c_show(&mut buf, args).unwrap());
 }

--- a/nucleus/src/main.rs
+++ b/nucleus/src/main.rs
@@ -75,6 +75,7 @@ fn init_mmu() {
         memory::mmu::init().unwrap();
     }
     println!("MMU initialised");
+    print_mmu_state_and_features();
 }
 
 fn init_exception_traps() {

--- a/nucleus/src/main.rs
+++ b/nucleus/src/main.rs
@@ -25,8 +25,6 @@
 #[cfg(not(target_arch = "aarch64"))]
 use architecture_not_supported_sorry;
 
-extern crate rlibc; // To enable linking memory intrinsics.
-
 /// Architecture-specific code.
 #[macro_use]
 pub mod arch;

--- a/nucleus/src/platform/rpi3/mailbox.rs
+++ b/nucleus/src/platform/rpi3/mailbox.rs
@@ -247,7 +247,7 @@ pub fn write(regs: &RegisterBlock, buf: *const u32, channel: u32) -> Result<()> 
     // (see FrameBuffer for example).
     // let buf_ptr = BcmHost::phys2bus(buf_ptr); not used for PropertyTags channel
 
-    println!("Mailbox::write {:x}/{:x}", buf_ptr, channel);
+    println!("Mailbox::write {:#08x}/{:#x}", buf_ptr, channel);
 
     // Insert a compiler fence that ensures that all stores to the
     // mailbox buffer are finished before the GPU is signaled (which is


### PR DESCRIPTION
* Set stack pointer immediately upon entry
* Disable alignment checks before enabling MMU (rust core lib likes to do unaligned half-word accesses from its fmt_u64 routine, which we use a lot)
* Print more detailed reports in kernel exception handler
* Clean up makefiles
* Dry up boot code
* Move build-std flags to cargo config, as they apply to all of the cargo invocations
* Remove rlibc dependency, use compiler built-ins instead
